### PR TITLE
Fix compatibility with older Node versions related to Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "url": "https://github.com/dryoma/postcss-media-query-parser/issues"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.5",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-cli": "^6.14.0",
+    "babel-preset-es2015": "^6.14.0",
     "babel-register": "^6.14.0",
     "eslint": "^2.5.1",
     "eslint-config-airbnb": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
-    "babel-tape-runner": "^2.0.1",
+    "babel-register": "^6.14.0",
     "eslint": "^2.5.1",
     "eslint-config-airbnb": "^6.0.2",
     "eslint-plugin-react": "^4.2.3",
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "lint": "eslint . --ignore-path .gitignore",
-    "test": "babel-tape-runner \"src/**/__tests__/*.js\"",
+    "test": "tape -r babel-register \"src/**/__tests__/*.js\"",
     "pretest": "npm run lint",
     "prebuild": "rimraf dist",
     "build": "babel src --out-dir dist"

--- a/src/nodes/Container.js
+++ b/src/nodes/Container.js
@@ -5,7 +5,6 @@
 import Node from './Node';
 
 function Container(opts) {
-  const _this = this;
   this.constructor(opts);
 
   this.nodes = opts.nodes;
@@ -25,7 +24,7 @@ function Container(opts) {
   }
 
   this.nodes.forEach(node => {
-    node.parent = _this; // eslint-disable-line no-param-reassign
+    node.parent = this; // eslint-disable-line no-param-reassign
   });
 }
 

--- a/src/nodes/Container.js
+++ b/src/nodes/Container.js
@@ -29,7 +29,7 @@ function Container(opts) {
   });
 }
 
-Container.prototype = Object.assign(Node.prototype);
+Container.prototype = Object.create(Node.prototype);
 Container.constructor = Node;
 
 /**


### PR DESCRIPTION
This PR introduces a fix and some refactoring. The primary purpose, however, is to remove dependency on [babel-tape-runner](https://github.com/wavded/babel-tape-runner), because it adds a polyfill (including `Object.assign`) to the **test runtime**, so functions relying on polyfills in older versions of Node pass tests but **break in production**. `tape -r babel-register` is simpler and more safe. See [wavded/babel-tape-runner#15](https://github.com/wavded/babel-tape-runner/issues/15).