### PR TITLE
Only pass strings to RegExp constructor

### DIFF
--- a/src/nodes/Container.js
+++ b/src/nodes/Container.js
@@ -44,12 +44,13 @@ Container.constructor = Node;
  * @return (boolean) false, if the iteration was broken
  */
 Container.prototype.walk = function walk(filter, cb) {
-  const callback = typeof(filter) === 'function' ? filter : cb;
-  const filterReg = filter instanceof RegExp ? filter : new RegExp(filter);
+  const hasFilter = typeof filter === 'string' || filter instanceof RegExp;
+  const callback = hasFilter ? cb : filter;
+  const filterReg = typeof filter === 'string' ? new RegExp(filter) : filter;
 
   for (let i = 0; i < this.nodes.length; i ++) {
     const node = this.nodes[i];
-    const filtered = !cb ? true : filterReg.test(node.type);
+    const filtered = hasFilter ? filterReg.test(node.type) : true;
     if (filtered && callback(node, i, this.nodes) === false) {
       return false;
     }


### PR DESCRIPTION
When running tests for `stylelint-scss` I noticed that `postcss-media-query-parser`'s walk method is throwing an error. 

I started looking at `walk` and realized that there was a problem when `filter` argument was used as a callback. The code was doing `new RegExp(filter)`, which in this case would be the callback function, which would then in some cases throw an error when called. 

I added some checks to verify that `filter` is a regular expression or a string, and that `new RegExp(filter)` is only done if `filter` is a string.